### PR TITLE
Send proxy queries in proxy mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,9 @@ Description:
     however strongly recommended to leave this setting commented out!
 
 > **Note:** the daemon needs an address on interfaces to operate, it is
-> expected that querierd runs on top of a bridge, and that the bridge
-> takes care of per-VLAN proxy queries.  Also, currently the daemon does
-> not react automatically to IP address changes, so it needs to be
-> SIGHUP'ed to use any new interface or address.
+> expected that querierd runs on top of a bridge. Also, currently the
+> daemon does not react automatically to IP address changes, so it needs
+> to be SIGHUP'ed to use any new interface or address.
 
 
 Motivation

--- a/src/defs.h
+++ b/src/defs.h
@@ -82,6 +82,11 @@ extern char		s2[MAX_INET_BUF_LEN];
 extern char		s3[MAX_INET_BUF_LEN];
 extern char		s4[MAX_INET_BUF_LEN];
 
+#define IGMP_PROXY_QUERY_MAXLEN (sizeof(struct ether_header)	+ \
+                                 sizeof(struct ip)		+ \
+                                 4 +				  \
+                                 IGMP_MINLEN)
+
 /*
  * Limit on length of route data
  */
@@ -145,8 +150,9 @@ extern void             resetlogging(void *);
 extern void		igmp_init(void);
 extern void		igmp_exit(void);
 extern void		accept_igmp(int, size_t);
-extern size_t		build_igmp(uint32_t, uint32_t, int, int, uint32_t, int);
+extern size_t		build_igmp(uint8_t *, uint32_t, uint32_t, int, int, uint32_t, int);
 extern void		send_igmp(int, uint32_t, uint32_t, int, int, uint32_t, int);
+extern void		send_igmp_proxy(const struct ifi *);
 extern char *		igmp_packet_kind(uint32_t, uint32_t);
 extern int		igmp_debug_kind(uint32_t, uint32_t);
 

--- a/src/iface.h
+++ b/src/iface.h
@@ -22,6 +22,7 @@ struct ifi {
     struct listaddr *ifi_querier;        /* IGMP querier (one or none)        */
     int		     ifi_timerid;	 /* IGMP query timer           	      */
     int		     ifi_igmpv1_warn;    /* To rate-limit IGMPv1 warnings     */
+    uint8_t	     ifi_hwaddr[6];	 /* MAC address of this interface     */
 };
 
 #define IFIF_DOWN		0x000100 /* kernel state of interface */


### PR DESCRIPTION
This patch adds support for sending proxy queries from source 0.0.0.0.

To get around the kernel filling in an "appropriate" src address we need
to use a raw packet socket and construct the ethernet frame + a correct
IPv4 header. A separate socket, and data buffer are added for this but
most of the data in the buffer can stay static after initialization. Only
the src MAC address changes depending on which interface should send the
proxy query.