### PR TITLE
Fix use-after-free on machines with unsigned-by-default chars

### DIFF
--- a/src/pev.c
+++ b/src/pev.c
@@ -22,7 +22,7 @@ struct pev {
 
 	int id;
 	char type;
-	char active;
+	signed char active;
 
 	union {
 		int sd;


### PR DESCRIPTION
With C being the bastion of user freedom, a compiler is of course free
to choose the signedness of a naked `char`. This means that for some
compiler/architecture combinations (notably GCC5/aarch64), `char` is
equivalent to `unsigned char`.

However, since an `active` value of -1 is used to signify a timer
queued for destruction, it is important that `active` is always of the
signed persuasion. Otherwise, `pev_check` will incorrectly determine
that the timer is still active, firing the callback once more.

When the timer callback was `delete_group_cb`, the callback context
would no longer be valid, leading to a SEGV.

Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>