### PR TITLE
Fix memory leak in join handler

### DIFF
--- a/src/pev.h
+++ b/src/pev.h
@@ -34,6 +34,12 @@ int pev_sig_add    (int signo, void (*cb)(int, void *), void *arg);
 int pev_sig_del    (int id);
 
 /*
+ * Destructor callback, called when deleting a signal event (pev_sig_del).
+ * Useful for deallocating heap allocated arg data.
+ */
+int pev_sig_set_cb_del  (int id, void (*cb)(void *));
+
+/*
  * Socket or file descriptor callback by sd/fd, only one callback per
  * descriptor.  API changes to CLOEXEC and NONBLOCK.  Delete by id
  * returned from pev_sock_add()
@@ -47,6 +53,12 @@ int pev_sock_del   (int id);
  */
 int pev_sock_open  (int domain, int type, int proto, void (*cb)(int, void *), void *arg);
 int pev_sock_close (int id);
+
+/*
+ * Destructor callback, called when deleting a socket event (pev_sock_del or
+ * pev_sock_close). Useful for deallocating heap allocated arg data.
+ */
+int pev_sock_set_cb_del  (int id, void (*cb)(void *));
 
 /*
  * Periodic timers use SIGALRM via setitimer() API, may affect use of
@@ -79,5 +91,11 @@ int pev_timer_del  (int id);
  */
 int pev_timer_set  (int id, int timeout);
 int pev_timer_get  (int id);
+
+/*
+ * Destructor callback, called when deleting a timer (pev_timer_del).
+ * Useful for deallocating heap allocated arg data.
+ */
+int pev_timer_set_cb_del  (int id, void (*cb)(void *));
 
 #endif /* PEV_H_ */


### PR DESCRIPTION
The timer for deleting a group entry has associated data allocated on the heap. This data must be freed not only when the timer times out, but also when receiving a new join for the same group in which case we replace the currently active timer.

This PR adds a few functions to the pev API. If this PR is accepted I'll try to upstream these to https://github.com/troglobit/pev/