### PR TITLE
Add new passive mode, where no queries are sent

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ version.
     robustness [2-10]                         # default: 2
     router-timeout [10-1024]                  # default: 255 sec
     
-    iface IFNAME [enable] [igmpv2 | igmpv3]   # default: disable
+    iface IFNAME [enable] [proxy-queries] [igmpv2 | igmpv3]   # default: disable
 
 Description:
 

--- a/src/cfparse.y
+++ b/src/cfparse.y
@@ -42,7 +42,7 @@ static struct ifi scrap;
 %token QUERY_INTERVAL QUERY_LAST_MEMBER_INTERVAL QUERY_RESPONSE_INTERVAL
 %token IGMP_ROBUSTNESS ROUTER_TIMEOUT ROUTER_ALERT
 %token NO PHYINT
-%token DISABLE ENABLE IGMPV1 IGMPV2 IGMPV3 STATIC_GROUP
+%token DISABLE ENABLE IGMPV1 IGMPV2 IGMPV3 STATIC_GROUP PROXY_QUERIES
 %token <num> BOOLEAN
 %token <num> NUMBER
 %token <ptr> STRING
@@ -117,6 +117,7 @@ ifmods	: /* empty */
 
 ifmod	: DISABLE		{ ifi->ifi_flags |= IFIF_DISABLED; }
 	| ENABLE		{ ifi->ifi_flags &= ~IFIF_DISABLED; }
+	| PROXY_QUERIES		{ ifi->ifi_flags |= IFIF_PROXY_QUERIES; }
 	| IGMPV1		{ ifi->ifi_flags &= ~IFIF_IGMPV2; ifi->ifi_flags |= IFIF_IGMPV1; }
 	| IGMPV2		{ ifi->ifi_flags &= ~IFIF_IGMPV1; ifi->ifi_flags |= IFIF_IGMPV2; }
 	| IGMPV3		{ ifi->ifi_flags &= ~IFIF_IGMPV1; ifi->ifi_flags &= ~IFIF_IGMPV2; }
@@ -232,6 +233,7 @@ static struct keyword {
 	{ "igmpv2",		IGMPV2, 0 },
 	{ "igmpv3",		IGMPV3, 0 },
 	{ "static-group",	STATIC_GROUP, 0 },
+	{ "proxy-queries",	PROXY_QUERIES, 0},
 	{ NULL,			0, 0 }
 };
 

--- a/src/iface.c
+++ b/src/iface.c
@@ -92,7 +92,7 @@ void iface_zero(struct ifi *ifi)
 
 static int iface_is_proxy(const struct ifi *ifi)
 {
-    return ifi->ifi_flags & IFIF_DISABLED;
+    return ifi->ifi_flags & IFIF_PROXY_QUERIES;
 }
 
 /*
@@ -344,7 +344,8 @@ static void start_iface(struct ifi *ifi)
     /*
      * Check if we should assume the querier role
      */
-    iface_check_election(ifi);
+    if (!(ifi->ifi_flags & IFIF_DISABLED))
+        iface_check_election(ifi);
 
     logit(LOG_INFO, 0, "Interface %s now in service", ifi->ifi_name);
 }
@@ -397,7 +398,7 @@ static void query_groups(int period, void *arg)
 {
     struct ifi *ifi = (struct ifi *)arg;
 
-    if (ifi->ifi_flags & IFIF_DOWN)
+    if (ifi->ifi_flags & (IFIF_DOWN | IFIF_DISABLED))
 	return;
 
     if (ifi->ifi_flags & IFIF_QUERIER)

--- a/src/iface.h
+++ b/src/iface.h
@@ -30,6 +30,7 @@ struct ifi {
 #define IFIF_QUERIER		0x000400 /* I am the subnet's querier */
 #define IFIF_IGMPV1		0x000800 /* Act as an IGMPv1 Router   */
 #define IFIF_IGMPV2		0x001000 /* Act as an IGMPv2 Router   */
+#define IFIF_PROXY_QUERIES	0x002000 /* Enable proxy queries      */
 
 struct phaddr {
     TAILQ_ENTRY(phaddr) pa_link;

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -291,6 +291,9 @@ static const char *ifstate(struct ifi *ifi)
 	if (ifi->ifi_flags & IFIF_DISABLED)
 		return "Disabled";
 
+	if (ifi->ifi_flags & IFIF_PROXY_QUERIES)
+		return "Proxy";
+
 	return "Up";
 }
 


### PR DESCRIPTION
Previously an interface could either be configured as enabled or disabled. When enabled, querierd takes part in querier election, and when disabled querierd can resort to sending proxy queries if no real querier is detected.

This patch changes disabled to mean that querierd should be completely passive and neither take part in querier election, nor send proxy queries. A new configuration option is added for enabling proxy queries called "proxy-queries". This gives us three modes of operation, compared to the two modes described above:

- Normal querier mode - when an iface is enabled and proxy-queries has not been enabled
- Proxy querier mode - when an iface is enabled and proxy-queries has been enabled
- (NEW) Passive querier mode - when an iface is disabled